### PR TITLE
Add imports to examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ You can learn how from this *free* series [How to Contribute to an Open Source P
 1. Fork the repo and create your branch from `master` (a guide on [how to fork a repository](https://help.github.com/articles/fork-a-repo/)).
 1. We have a commit message convention:
     - `fix` - bug fixes
-    - `feature` -  new features, e.g. add GrouppedList component
+    - `feature` -  new features, e.g. add GroupedList component
     - `docs` - code/structure refactor, e.g. new structure folder for components
     - `refactor` - changes into documentation, e.g. add usage example for Button
     - `chore` - tooling changes, e.g. change circle ci config

--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -8,7 +8,9 @@ Avatar component.
 ![Avatar component](assets/avatar.png)
 
 Example usage:
-```javascript
+```jsx
+import { Avatar } from 'react-native-ios-kit';
+
 <Avatar initials="CK" size={30} />
 ```
 

--- a/docs/button.md
+++ b/docs/button.md
@@ -8,7 +8,9 @@ A basic Button component.
 ![Button component](assets/buttons.png)
 
 Example usage:
-```javascript
+```jsx
+import { Button } from 'react-native-ios-kit';
+
 <Button style={styles.button} inline rounded>
   Button (inline/rounded)
 </Button>

--- a/docs/checkbox-row.md
+++ b/docs/checkbox-row.md
@@ -6,9 +6,11 @@ title: CheckboxRow
 RowItem with Checkmark Icon on right side.
 
 ![CheckboxRow component](assets/checkbox-row.png)
- 
+
 Example usage:
 ```jsx
+import { CheckboxRow } from 'react-native-ios-kit';
+
 <CheckboxRow
   selected={this.state.checkboxSelected}
   onPress={() =>
@@ -44,6 +46,5 @@ Indicates whether checkbox is selected or not.
 
 ### `theme` (optional)
 **type:** [`Theme`](theme.html)
- 
-Custom theme for component. By default provided by the ThemeProvider.
 
+Custom theme for component. By default provided by the ThemeProvider.

--- a/docs/collection.md
+++ b/docs/collection.md
@@ -9,6 +9,8 @@ A Collection manages an ordered set of content, such as a set of photos, and pre
 
 Example usage:
 ```jsx
+import { Collection } from 'react-native-ios-kit';
+
 <Collection
   numberOfColumns={4}
   data={data}
@@ -71,7 +73,7 @@ Function called once user pulls to refresh. Must be used in conjunction with `re
 ### `refreshing` (optional)
 **type:** `boolean`
 
-Bollean indicating if ActivityIndicator should be shown.
+Boolean indicating if ActivityIndicator should be shown.
 
 ### `renderItem`
 **type** `(item: *) => React.Element<*>`

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,7 +10,7 @@ Check the [Theme Type](theme.html) to see what customization options are support
 
 Example:
 
-```javascript
+```jsx
 import * as React from 'react';
 import { AppRegistry } from 'react-native';
 import { DefaultTheme, ThemeProvider } from 'react-native-ios-kit';
@@ -38,13 +38,15 @@ function Main() {
 You can also customize theme per one component by using `theme` prop.
 
 Example:
-```
-  <Icon
-    name="ios-people"
-    theme={{
-      primaryColor: 'green'
-    }}
-  >
+```jsx
+import { Icon } from 'react-native-ios-kit';
+
+<Icon
+  name="ios-people"
+  theme={{
+    primaryColor: 'green'
+  }}
+>
 ```
 This code will change icon color to `green`
 
@@ -54,7 +56,9 @@ You can access theme in your own components using the `withTheme` HOC exported f
 Components wrapped with `withTheme` support the theme from the `ThemeProvider` as well as from the `theme` prop.
 
 Example:
-```
+```jsx
+import { Text } from 'react-native';
+
 const CustomComponent = ({ theme }) => (
   <Text style={{ color: theme.primaryColor }}>
     Morning!

--- a/docs/grouped-list.md
+++ b/docs/grouped-list.md
@@ -10,6 +10,8 @@ It simulates iOS contact list.
 
 Example usage:
 ```jsx
+import { GroupedList } from 'react-native-ios-kit';
+
 <GroupedList
   sections={['a','b','c','d','e']}
   renderItem={({ item }) => (

--- a/docs/icon.md
+++ b/docs/icon.md
@@ -7,8 +7,10 @@ Icon component.
 
 ![Icon component](assets/icon.png)
 
-Example usage: 
+Example usage:
 ```jsx
+import { Icon } from 'react-native-ios-kit';
+
 <Icon
   name={'ios-paper-outline'}
   size={30}
@@ -52,4 +54,3 @@ Custom styles to apply to the Icon.
 **type:** [`Theme`](theme.html)
 
 Custom theme for component. By default provided by the ThemeProvider.
-

--- a/docs/info-row.md
+++ b/docs/info-row.md
@@ -6,17 +6,19 @@ title: InfoRow
 Basic Row to display additional information on right side.
 
 ![InfoRow component](assets/info-row.png)
- 
+
 
 Example usage:
 ```jsx
+import { InfoRow } from 'react-native-ios-kit';
+
 <InfoRow title="InfoRow" info="1" />
 ```
 
 ## Theme
 Uses following `theme` properties:
 - `placeholderColor` - color of info string.
- 
+
 ## Props
 
 ### [RowItem props...](row-item.html#props)
@@ -30,5 +32,5 @@ Information to be displayed at right side of row.
 
 ### `theme` (optional)
 **type:** [`Theme`](theme.html)
- 
+
 Custom theme for component. By default provided by the ThemeProvider.

--- a/docs/navigation-row.md
+++ b/docs/navigation-row.md
@@ -6,9 +6,11 @@ title: NavigationRow
 RowItem with information and RightArrow Icon on right side.
 
 ![NavigationRow component](assets/navigation-row.png)
- 
+
 Example usage:
 ```jsx
+import { NavigationRow } from 'react-native-ios-kit';
+
 <NavigationRow
   title="NavigationRow"
   onPress={() => alert('NavigationRow pressed')}
@@ -38,5 +40,5 @@ Additional information to be displayed next to RightArrow Icon.
 
 ### `theme` (optional)
 **type:** [`Theme`](theme.html)
- 
+
 Custom theme for component. By default provided by the ThemeProvider.

--- a/docs/page-control-view.md
+++ b/docs/page-control-view.md
@@ -7,8 +7,10 @@ PageControlView swipeable view with PageControls at the bottom of the screen.
 
 ![PageControl component](assets/page-control-view.gif)
 
-Example usage: 
+Example usage:
 ```jsx
+import { PageControlView } from 'react-native-ios-kit';
+
 <PageControlView defaultPage={1}>
   <View style={styles.container}>
     <Title1>First page.</Title1>

--- a/docs/page-control.md
+++ b/docs/page-control.md
@@ -7,8 +7,10 @@ PageControl component shows the position of the current page in a flat list of p
 
 ![PageControl component](assets/page-control.png)
 
-Example usage: 
+Example usage:
 ```jsx
+import { PageControl } from 'react-native-ios-kit';
+
 <PageControl
   currentPage={currentPage}
   numberOfPages={5}
@@ -25,7 +27,7 @@ Uses following `theme` properties:
 
 ## Props
 
-### `currentPage` 
+### `currentPage`
 **type:** `number`  
 
 Selected pages index.
@@ -60,7 +62,7 @@ Size of the controls.
 
 Custom theme for component. By default provided by the ThemeProvider.
 
-### `updateCurrentPageDisplay` 
+### `updateCurrentPageDisplay`
 **type:** `number => void`
 
 Callback function to be fired when user taps controls.

--- a/docs/progress-view.md
+++ b/docs/progress-view.md
@@ -7,8 +7,10 @@ Displays horizontal progress bar.
 
 ![ProgressBar component](assets/progress-bar.gif)
 
-Example usage: 
+Example usage:
 ```jsx
+import { ProgressBar } from 'react-native-ios-kit';
+
 <ProgressBar progress={this.state.progress} />
 ```
 

--- a/docs/row-item.md
+++ b/docs/row-item.md
@@ -9,6 +9,8 @@ A component you can use as a children for [`TableView`](table-view.html).
 
 Example usage:
 ```jsx
+import { RowItem } from 'react-native-ios-kit';
+
 <RowItem
   icon="ios-map-outline"
   title="Navigation"

--- a/docs/searchbar.md
+++ b/docs/searchbar.md
@@ -4,9 +4,11 @@ title: SearchBar
 ---
 
 ![SearchBar component](assets/search-bar.gif)
- 
+
 Example usage:
 ```jsx
+import { SearchBar } from 'react-native-ios-kit';
+
 <SearchBar
   value={this.state.text}
   onValueChange={text => this.setState({ text })}
@@ -26,19 +28,19 @@ Uses following `theme` properties:
 
 ## Props
 
-### `animated` (optional) 
+### `animated` (optional)
 **type:** `boolean`  
 **default value:** `false`
 
 Indicates if Cancel button and TextInput should animate on focus/blur.
 
-### `animationTime` (optional) 
+### `animationTime` (optional)
 **type:** `number`  
 **default value:** `200`
 
-Animation duration in milliseconds. 
+Animation duration in milliseconds.
 
-### `cancelText` (optional) 
+### `cancelText` (optional)
 **type:** `string`  
 **default value:** `"Cancel"`
 
@@ -49,17 +51,17 @@ Text of Cancel Button.
 
 Callback invoked on text input blur
 
-### `onValueChange` 
+### `onValueChange`
 **type:** `(text: string) => void`  
 
 Invoked with the new value when the value of text input changes.
 
-### `onFocus` (optional) 
+### `onFocus` (optional)
 **type:** `() => void`  
 
 Callback invoked on text input focus
 
-### `placeholder` (optional) 
+### `placeholder` (optional)
 **type:** `string`  
 **default value:** `"Search"`
 
@@ -67,15 +69,15 @@ Placeholder of text input. Defaults to "Search".
 
 ### `theme` (optional)
 **type:** [`Theme`](theme.html)
- 
+
 Custom theme for component. By default provided by the ThemeProvider.
 
-### `value` 
+### `value`
 **type:** `string`  
 
 Value of text input.
 
-### `withCancel` (optional) 
+### `withCancel` (optional)
 **type:** `boolean`  
 **default value:** `false`
 

--- a/docs/segmented-control.md
+++ b/docs/segmented-control.md
@@ -3,12 +3,14 @@ id: segmented-control
 title: SegmentedControl
 ---
 
-Linear set of two or more segments, each of which functions as a mutually exclusive button. 
+Linear set of two or more segments, each of which functions as a mutually exclusive button.
 
 ![Segmented Control](assets/segmented-control.png)
 
 Example usage:
 ```jsx
+import { SegmentedControl } from 'react-native-ios-kit';
+
 <SegmentedControl
   values={['One', 'Two', 'Three']}
   selectedIndex={this.state.selectedIndex}
@@ -24,14 +26,14 @@ Example usage:
 
 ## Theme
 Uses following `theme` properties:
-- `primaryColor` - SegmentedControl's `tintColor` 
+- `primaryColor` - SegmentedControl's `tintColor`
 
 ## Props
 
 ## `onValueChange`
 **type:** `(value: string, index: number) => void`
 
-Callback that is called when the user taps a segment. 
+Callback that is called when the user taps a segment.
 Passes the segment's value and index as arguments.
 
 ### `selectedIndex`
@@ -54,4 +56,3 @@ Accent color of SegmentedControl.
 **type:** `Array<string>`
 
 Labels of the control's segment buttons.
-

--- a/docs/slider.md
+++ b/docs/slider.md
@@ -7,8 +7,10 @@ Slider component.
 
 ![Slider component](assets/slider.png)
 
-Example usage: 
+Example usage:
 ```jsx
+import { Slider } from 'react-native-ios-kit';
+
 <Slider
   value={this.state.value2}
   onValueChange={value => this.setState({ value2: value })}
@@ -55,7 +57,7 @@ The color used for the track to the right of the button.
 **type:** `number`   
 **default value:** 100
 
-Maximum value of the slider. 
+Maximum value of the slider.
 
 ### `minIconColor` (optional)
 **type:** `string`
@@ -64,7 +66,7 @@ Maximum value of the slider.
 Color of the minimum track icon (on the left side).
 
 ### `minIconName` (optional)
-**type:** `string` 
+**type:** `string`
 
 Name of the minimum track icon (on the left side).
 
@@ -84,7 +86,7 @@ The color used for the track to the left of the button.
 **type:** `number`   
 **default value:** 0
 
-Minimum value of the slider. 
+Minimum value of the slider.
 
 ### `onSlidingComplete` (optional)
 **type:** `(value: number) => void`

--- a/docs/spinner.md
+++ b/docs/spinner.md
@@ -7,8 +7,10 @@ Displays a circular loading indicator.
 
 ![Spinner component](assets/spinner.gif)
 
-Example usage: 
+Example usage:
 ```jsx
+import { Spinner } from 'react-native-ios-kit';
+
 <Spinner animating={this.state.loading} />
 ```
 

--- a/docs/stepper.md
+++ b/docs/stepper.md
@@ -9,6 +9,8 @@ Two-segment control used to increase or decrease an incremental value.
 
 Example usage:
 ```jsx
+import { Stepper } from 'react-native-ios-kit';
+
 <Stepper
   value={this.state.value}
   onValueChange={value => this.setState({ value })}
@@ -19,7 +21,7 @@ Example usage:
 
 ## Theme
 Uses following `theme` properties:
-- `primaryColor` - Stepper borders and Icon color 
+- `primaryColor` - Stepper borders and Icon color
 - `primaryLightColor` - pressed in background color, inactive color of Stepper button
 ## Props
 
@@ -50,9 +52,7 @@ The step, or increment, value for the stepper.
 
 Custom theme for component. By default provided by the ThemeProvider.
 
-
 ### `value`
 **type:** `number`
 
 The numeric value of the stepper.
-

--- a/docs/switch-row.md
+++ b/docs/switch-row.md
@@ -6,10 +6,12 @@ title: SwitchRow
 RowItem with Switch button as RightComponent.
 
 ![SwitchRow component](assets/switch-row.png)
- 
+
 
 Example usage:
 ```jsx
+import { SwitchRow } from 'react-native-ios-kit';
+
 <SwitchRow
   title="SwitchRow"
   value={this.state.switchSelected}
@@ -19,7 +21,7 @@ Example usage:
 
 ## Theme
 Uses following `theme` properties:
-- `positiveColor` - selected switch background color (`onTintColor`) 
+- `positiveColor` - selected switch background color (`onTintColor`)
 
 ## Props
 
@@ -34,7 +36,7 @@ Invoked with the new value when the value changes.
 
 ### `theme` (optional)
 **type:** [`Theme`](theme.html)
- 
+
 Custom theme for component. By default provided by the ThemeProvider.
 
 ### `value`

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -3,12 +3,14 @@ id: switch
 title: Switch
 ---
 
-A basic Switch component that should render native ios switch.
+A basic Switch component that should render native iOS switch.
 
 ![Switch component](assets/toggle-button.png)
 
 Example usage:
 ```jsx
+import { Switch } from 'react-native-ios-kit';
+
 <Switch
   value={this.state.switchValue}
   onValueChange={value => this.setState({ switchValue: value })}
@@ -17,7 +19,7 @@ Example usage:
 
 ## Theme
 Uses following `theme` properties:
-- `positiveColor` - selected switch background color (`onTintColor`) 
+- `positiveColor` - selected switch background color (`onTintColor`)
 
 ## Props
 

--- a/docs/tab-bar.md
+++ b/docs/tab-bar.md
@@ -7,6 +7,8 @@ title: TabBar
 
 Example usage:
 ```jsx
+import { TabBar } from 'react-native-ios-kit';
+
 <TabBar
   tabs={[
     {

--- a/docs/table-view.md
+++ b/docs/table-view.md
@@ -3,7 +3,7 @@ id: table-view
 title: TableView
 ---
 
-A basic TableView component that can render ios table view.
+A basic TableView component that can render iOS table view.
 It renders header, footer and children which can be [`RowItem`](row-item.html) components.  
 
 
@@ -11,6 +11,8 @@ It renders header, footer and children which can be [`RowItem`](row-item.html) c
 
 Example usage:
 ```jsx
+import { ScrollView } from 'react-native-ios-kit';
+
 <ScrollView>
   <TableView header="Header" footer="footer...">
     <RowItem

--- a/docs/text-field-row.md
+++ b/docs/text-field-row.md
@@ -10,6 +10,8 @@ TextInput focuses on Row press.
 
 Example usage:
 ```jsx
+import { TextFieldRow } from 'react-native-ios-kit';
+
 <TextFieldRow
   title="TextFieldRow"
   value={this.state.textFieldValue}

--- a/docs/text-field.md
+++ b/docs/text-field.md
@@ -10,6 +10,8 @@ Used to request a small amount of information, such as an email address.
 
 Example usage:
 ```jsx
+import { TextField } from 'react-native-ios-kit';
+
 <TextField
   placeholder={'Phone number'}
   value={this.state.phone}

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -8,7 +8,7 @@ Basic typography components.
 ![Typography components](assets/typography.png)
 
 Example usage:
-```javascript
+```jsx
 <Title1>Title 1</Title1>
 <Title2>Title2</Title2>
 <Title3>Title3</Title3>
@@ -48,6 +48,3 @@ Custom styles to apply to the typography component.
 **type:** [`Theme`](theme.html)
 
 Custom theme for component. By default provided by the ThemeProvider.
-
-
-

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ It's a good idea to wrap the component which is passed to `AppRegistry.registerC
 
 Example:
 
-```javascript
+```jsx
 import * as React from 'react';
 import { AppRegistry } from 'react-native';
 import { ThemeProvider } from 'react-native-ios-kit';
@@ -27,7 +27,3 @@ AppRegistry.registerComponent('main', () => Main);
 ```
 
 The `ThemeProvider` component provides the theme to all the components in the framework. It also acts as a portal to components which need to be rendered at the top level.
-
-
-
-

--- a/src/components/GroupedList/GroupedList.js
+++ b/src/components/GroupedList/GroupedList.js
@@ -51,7 +51,7 @@ class GroupedList extends React.PureComponent<Props, State> {
   sectionHeadersHeights: { [key: string]: number } = {};
 
   groupItems(items: Array<Object>): any {
-    const groupped = items.reduce((acc, item) => {
+    const grouped = items.reduce((acc, item) => {
       const groupId = this.props.groupBy(item);
       if (Object.prototype.hasOwnProperty.call(acc, groupId)) {
         acc[groupId].data.push(item);
@@ -61,7 +61,7 @@ class GroupedList extends React.PureComponent<Props, State> {
       return acc;
     }, {});
 
-    return Object.values(groupped);
+    return Object.values(grouped);
   }
 
   handleSectionPress = (sectionIdx: number) => {


### PR DESCRIPTION
Just like [the paper issue added by @thymikee](https://github.com/callstack/react-native-paper/issues/223), this adds imports for doc examples. I was also able to find & fix some minor inconsistencies and typos.