### PR TITLE
docs: toolbar import

### DIFF
--- a/docs/toolbar.md
+++ b/docs/toolbar.md
@@ -9,6 +9,8 @@ Just like TabBar, the Toolbar component appears on the bottom of the application
 
 Example usage:
 ```jsx
+import { Toolbar } from 'react-native-ios-kit';
+
 <Toolbar
   items={[
     {


### PR DESCRIPTION
Minor docs update. Since #106 and #104 was merged, this adds the missing import to the Toolbar example.