### PR TITLE
fix align icon and info in NavigationRow

### DIFF
--- a/src/components/NavigationRow.js
+++ b/src/components/NavigationRow.js
@@ -24,7 +24,7 @@ class NavigationRow extends React.Component<Props> {
             {info}
           </Body>
         ) : null}
-        <Icon name="ios-arrow-forward" size={22} color={placeholderColor} />
+        <Icon name="ios-arrow-forward" size={20} color={placeholderColor} style={{ marginTop: 4 }}/>
       </View>
     );
   };
@@ -45,5 +45,6 @@ export default withTheme(NavigationRow);
 const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
+    alignItems: 'center',
   },
 });

--- a/src/components/RowItem.js
+++ b/src/components/RowItem.js
@@ -136,7 +136,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 15,
-    paddingVertical: 4,
     minHeight: 43,
   },
   titleWrapper: {
@@ -149,5 +148,6 @@ const styles = StyleSheet.create({
   rightComponent: {
     flexGrow: 1,
     alignItems: 'flex-end',
+    justifyContent: 'center',
   },
 });


### PR DESCRIPTION
At this point in NavigationRow, the icon and info fields are not aligned with the title field.
Made alignment and resized the button to native