### PR TITLE
Allow to disable clearButton in TextField

### DIFF
--- a/docs/text-field.md
+++ b/docs/text-field.md
@@ -62,3 +62,8 @@ Custom theme for component. By default provided by the ThemeProvider.
 **type:** `string`
 
 Value of TextInput
+
+### `clearButton`
+**type** `boolean`
+
+Display the custom button to clear the input. By default the button is shown.

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -12,6 +12,7 @@ type Props = {
   theme: Theme,
   placeholder?: string,
   value: string,
+  clearButton?: boolean,
   onValueChange?: (text: string) => void,
   containerStyle?: StyleObj,
   inputStyle?: StyleObj,
@@ -25,6 +26,7 @@ class TextField extends React.Component<Props> {
       value,
       placeholder,
       onValueChange,
+      clearButton,
       theme: {
         backgroundColor,
         dividerColor,
@@ -53,7 +55,7 @@ class TextField extends React.Component<Props> {
           style={[styles.input, { color: textColor }, inputStyle]}
           selectionColor={primaryColor}
         />
-        {value ? (
+        {value && clearButton !== false ? (
           <TouchableOpacity onPress={this.clearInput}>
             <Icon
               name="ios-close-circle"


### PR DESCRIPTION
## Summary

This PR allows to disable the clearButton in the `TextField` component. This allows to use more advanced behaviors of the  `TextInput` component via the [clearButtonMode](https://facebook.github.io/react-native/docs/textinput#clearbuttonmode).

## Reviewers

* [x] Ready for review :+1: