### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -29,6 +29,10 @@ const siteConfig = {
   // You may provide arbitrary config keys to be used as needed by your template.
   repoUrl: 'https://github.com/callstack/react-native-ios-kit',
   ogImage: 'img/ios-kit.svg',
+  algolia: {
+    apiKey: '3fc3f7484d62d6435dfb39ab39ed8b24',
+    indexName: 'react-native-ios-kit', 
+  },
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.