### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,6 +1,10 @@
 const users = [{}];
 
 const siteConfig = {
+  algolia: {
+    apiKey: '3fc3f7484d62d6435dfb39ab39ed8b24',
+    indexName: 'react-native-ios-kit',
+  },
   companyName: 'Callstack',
   title: 'react-native-ios-kit',
   tagline: 'The missing React Native UI Kit for iOS.',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.