### PR TITLE
Fix - Add testID prop to button

### DIFF
--- a/docs/button.md
+++ b/docs/button.md
@@ -98,3 +98,8 @@ Custom styles to apply to the button.
 **type:** [`Theme`](theme.html)
 
 Custom theme for component. By default provided by the ThemeProvider.
+
+### `testID` (optional)
+**type:** `string`  
+
+Used to locate the item in end-to-end tests.

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -65,7 +65,7 @@ type Props = {
   /**
    * Used to locate the item for end to end tests
    */
-  testID?: string
+  testID?: string,
 };
 
 class Button extends React.Component<Props> {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -62,6 +62,10 @@ type Props = {
    */
   disabledStyle?: ViewStyleProp,
   children: React.Element<*> | React.Element<*>[] | string,
+  /**
+   * Used to locate the item for end to end tests
+   */
+  testID?: string
 };
 
 class Button extends React.Component<Props> {
@@ -144,6 +148,7 @@ class Button extends React.Component<Props> {
         onPressOut={this.props.onPressOut}
         onLongPress={this.props.onLongPress}
         accessibilityRole="button"
+        testID={this.props.testID}
         style={[
           this.styles.default.container,
           ...container,


### PR DESCRIPTION
### Summary

Currently, Button doesn't support the `testID` prop. It is not documented that well in react-native but it does support it. This pr add that support.
Example of it being [used](https://callstack.github.io/react-native-testing-library/docs/api.html#fireeventchangetext-element-reacttestinstance-data-arrayany--void). 
