### PR TITLE
chore: ci config - workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,6 @@ aliases:
     key: dependencies-website-{{ checksum "website/package.json" }}
     paths: website/node_modules
 
-  - &filter-only-master
-    branches:
-      only: master
-
   - &filter-ignore-gh-pages
     branches:
       ignore: gh-pages
@@ -101,30 +97,21 @@ jobs:
           yarn exp login -u "$EXP_USERNAME" -p "$EXP_PASSWORD"
           yarn exp publish --non-interactive
 
-  # deploy:
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: ~/react-native-ios-kit
-  #     - run: |
-  #         npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-  #         npm publish
-
 workflows:
   version: 2
 
-  build-and-test:
+  test:
     jobs:
       - build:
-          filters:
-            tags:
-              only: /.*/
+          filters: *filter-ignore-gh-pages
       - tests:
           requires:
             - build
-          filters: *filter-ignore-gh-pages
-      # - deploy:
-      #     filters: *filter-tag
+
+  release:
+    jobs:
+      - build:
+          filters: *filter-tag
       - deploy-website:
           requires:
             - build


### PR DESCRIPTION
### Summary

Two separate CI workflows - build + tests for regular flow and build + releases for `tag`s 