### PR TITLE
Add useTheme hook to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ After you're done, you can run `yarn && yarn start` in the `example/` folder and
 
 ## Working on documentation
 
-We use [docusaurus](https://docusaurus.io). If you want to make changes in documentation feel free to add/edit files inside `/docs` directory. For more information about creating docs with docusaurus see it's [documentation](https://docusaurus.io/docs/en/installation.html).
+We use [docusaurus](https://docusaurus.io). If you want to make changes in documentation feel free to add/edit files inside `/docs` directory. For more information about creating docs with docusaurus see it's [documentation](https://docusaurus.io/docs/en/installation).
 
 ## Reporting New Issues
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The **ThemeProvider** component provides the theme to all the components in the 
 #### Main theme for application
 
 You can provide a custom theme to customize the colors, fonts etc. with the **ThemeProvider** component.
-Check the [Theme Type](https://callstack.github.io/react-native-ios-kit/docs/theme.html) to see what customization options are supported.
+Check the [Theme Type](https://callstack.github.io/react-native-ios-kit/docs/theme) to see what customization options are supported.
 
 Example:
 

--- a/website/docs/avatar.md
+++ b/website/docs/avatar.md
@@ -41,7 +41,7 @@ Size of an Avatar.
 Custom styles to apply to Avatar.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/button.md
+++ b/website/docs/button.md
@@ -97,7 +97,7 @@ If true, make border corners rounded.
 Custom styles to apply to the button.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/checkbox-row.md
+++ b/website/docs/checkbox-row.md
@@ -32,7 +32,7 @@ Uses following `theme` properties:
 
 ## Props
 
-### [RowItem props...](row-item.html#props)
+### [RowItem props...](row-item#props)
 
 Other props accepted by `RowItem` component.
 
@@ -47,6 +47,6 @@ Event fired when Row is pressed in.
 Indicates whether checkbox is selected or not.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/collection.md
+++ b/website/docs/collection.md
@@ -100,6 +100,6 @@ Function rendering footer of each section.
 Makes section headers stick to the top of the screen until the next one pushes it off.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/customization.md
+++ b/website/docs/customization.md
@@ -39,6 +39,7 @@ You can also customize theme per one component by using `theme` prop.
 
 Example:
 ```jsx
+import * as React from 'react';
 import { Icon } from 'react-native-ios-kit';
 
 <Icon
@@ -51,13 +52,15 @@ import { Icon } from 'react-native-ios-kit';
 This code will change icon color to `green`
 
 ## Using the theme in your own components
-You can access theme in your own components using the `withTheme` HOC exported from the library. You will receive [`theme`](theme.html) prop if you wrap your component with the HOC.
+You can access theme in your own components using the `withTheme` HOC exported from the library. You will receive [`theme`](theme) prop if you wrap your component with the HOC.
 
 Components wrapped with `withTheme` support the theme from the `ThemeProvider` as well as from the `theme` prop.
 
 Example:
 ```jsx
+import * as React from 'react';
 import { Text } from 'react-native';
+import { withTheme } from 'react-native-ios-kit';
 
 const CustomComponent = ({ theme }) => (
   <Text style={{ color: theme.primaryColor }}>
@@ -66,4 +69,22 @@ const CustomComponent = ({ theme }) => (
 )
 
 export default withTheme(CustomComponent);
+```
+
+You can also use `useTheme` hook: 
+```jsx
+import * as React from 'react';
+import { Text } from 'react-native';
+import { useTheme } from 'react-native-ios-kit';
+
+const CustomComponent = () => {
+  const theme = useTheme()
+  return (
+    <Text style={{ color: theme.primaryColor }}>
+      Morning!
+    </Text>
+  )
+}
+
+export default CustomComponent;
 ```

--- a/website/docs/grouped-list.md
+++ b/website/docs/grouped-list.md
@@ -105,6 +105,6 @@ Rendered at the top and bottom of each section (note this is different from Item
 Styles to apply on section list.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/icon.md
+++ b/website/docs/icon.md
@@ -28,7 +28,7 @@ Uses following `theme` properties:
 
 ### `color` (optional)
 **type:** `string`  
-**default value:** `primaryColor` from [`theme`](theme.html)
+**default value:** `primaryColor` from [`theme`](theme)
 
 Custom color for icon.
 
@@ -53,6 +53,6 @@ Icon size.
 Custom styles to apply to the Icon.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/info-row.md
+++ b/website/docs/info-row.md
@@ -23,7 +23,7 @@ Uses following `theme` properties:
 
 ## Props
 
-### [RowItem props...](row-item.html#props)
+### [RowItem props...](row-item#props)
 
 Other props accepted by `RowItem` component.
 
@@ -33,6 +33,6 @@ Other props accepted by `RowItem` component.
 Information to be displayed at right side of row.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/navigation-row.md
+++ b/website/docs/navigation-row.md
@@ -26,7 +26,7 @@ Uses following theme properties:
 
 ## Props
 
-### [RowItem props...](row-item.html#props)
+### [RowItem props...](row-item#props)
 
 Other props accepted by `RowItem` component
 
@@ -41,6 +41,6 @@ Additional information to be displayed next to RightArrow Icon.
 `onPress` event fired when user presses Row.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/page-control-view.md
+++ b/website/docs/page-control-view.md
@@ -45,7 +45,7 @@ Style of wrapper container.
 
 ### `currentPageIndicatorTintColor` (optional),
 **type:** `string`  
-**default value:** `barColor` from [`theme`](theme.html)
+**default value:** `barColor` from [`theme`](theme)
 
 ### `onPageChange` (optional)  
 **type:** `number => void`  
@@ -55,7 +55,7 @@ Event handler called when current page changes
 
 ### `pageIndicatorTintColor` (optional)  
 **type:** `string`  
-**default value:** `dividerColor` from [`theme`](theme.html)
+**default value:** `dividerColor` from [`theme`](theme)
 
 ### `pageIndicatorSize` (optional)  
 **type:** `number`  
@@ -68,6 +68,6 @@ Size of the controls.
 **default value:** `0`  
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/page-control.md
+++ b/website/docs/page-control.md
@@ -36,7 +36,7 @@ Selected pages index.
 
 ### `currentPageIndicatorTintColor` (optional),
 **type:** `string`  
-**default value:** `barColor` from [`theme`](theme.html)
+**default value:** `barColor` from [`theme`](theme)
 
 ### `hidesForSinglePage` (optional)
 **type:** `boolean`  
@@ -51,7 +51,7 @@ The number of pages the receiver shows (as dots).
 
 ### `pageIndicatorTintColor` (optional)  
 **type:** `string`  
-**default value:** `dividerColor` from [`theme`](theme.html)
+**default value:** `dividerColor` from [`theme`](theme)
 
 ### `size` (optional)  
 **type:** `number`  
@@ -60,7 +60,7 @@ The number of pages the receiver shows (as dots).
 Size of the controls.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/progress-view.md
+++ b/website/docs/progress-view.md
@@ -27,6 +27,6 @@ Uses following `theme` properties:
 Current value of progress.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/row-item.md
+++ b/website/docs/row-item.md
@@ -39,7 +39,7 @@ Uses following theme properties:
 ### `icon` (optional)
 **type:** `ImageSource`
 
-ImageSource. See ['Icon`](icon.html#name)
+ImageSource. See ['Icon`](icon#name)
 
 ### `onPress` (optional)
 **type:** `() => void`
@@ -63,7 +63,7 @@ Component to be displayed on the right side of row. It can be use interchangeabl
 Subtitle text to be displayed.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/searchbar.md
+++ b/website/docs/searchbar.md
@@ -69,7 +69,7 @@ Callback invoked on text input focus
 Placeholder of text input. Defaults to "Search".
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/segmented-control.md
+++ b/website/docs/segmented-control.md
@@ -43,13 +43,13 @@ Passes the segment's value and index as arguments.
 Index of currently selected `value`.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 
 ### `tintColor` (optional)
 **type:** `string`  
-**default value:** `primaryColor` from [`theme`](theme.html)
+**default value:** `primaryColor` from [`theme`](theme)
 
 Accent color of SegmentedControl.
 

--- a/website/docs/slider.md
+++ b/website/docs/slider.md
@@ -33,7 +33,7 @@ Uses following `theme` properties:
 
 ### `maxIconColor` (optional)
 **type:** `string`
-**default value:** `placeholderColor` from [theme](./theme.html)
+**default value:** `placeholderColor` from [theme](./theme)
 
 Color of the maximum track icon (on the right side).
 
@@ -50,7 +50,7 @@ Size of the maximum track icon (on the right side).
 
 ### `maxTrackTintColor` (optional)
 **type:** `string`
-**default value:** `dividerColor` from [theme](./theme.html)
+**default value:** `dividerColor` from [theme](./theme)
 
 The color used for the track to the right of the button.
 
@@ -62,7 +62,7 @@ Maximum value of the slider.
 
 ### `minIconColor` (optional)
 **type:** `string`
-**default value:** `placeholderColor` from [theme](./theme.html)
+**default value:** `placeholderColor` from [theme](./theme)
 
 Color of the minimum track icon (on the left side).
 
@@ -79,7 +79,7 @@ Size of the minimum track icon (on the left side).
 
 ### `minTrackTintColor` (optional)
 **type:** `string`
-**default value:** `primaryColor` from [theme](./theme.html)
+**default value:** `primaryColor` from [theme](./theme)
 
 The color used for the track to the left of the button.
 
@@ -112,7 +112,7 @@ Step value of the slider. The value should be between 0 and (maximumValue - mini
 Custom styles to apply to the Icon.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/spinner.md
+++ b/website/docs/spinner.md
@@ -40,6 +40,6 @@ Whether the indicator should hide when not animating.
 Size of the indicator.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/docs/stepper.md
+++ b/website/docs/stepper.md
@@ -49,7 +49,7 @@ Callback function on changing counter result
 The step, or increment, value for the stepper.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/switch-row.md
+++ b/website/docs/switch-row.md
@@ -35,7 +35,7 @@ Other props accepted by `RowItem` component.
 Invoked with the new value when the value changes.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/switch.md
+++ b/website/docs/switch.md
@@ -36,7 +36,7 @@ Invoked with the new value when the value changes.
 
 ### `trackColor` (optional)
 **type:** `string`
-**default value:** `positiveColor` from [`theme`](theme.html)
+**default value:** `positiveColor` from [`theme`](theme)
 
 Background color when the switch is turned on.
 
@@ -46,7 +46,7 @@ Background color when the switch is turned on.
 Switch style.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/tab-bar.md
+++ b/website/docs/tab-bar.md
@@ -52,7 +52,7 @@ Uses following `theme` properties:
 ## Props
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 
@@ -60,7 +60,7 @@ Custom theme for component. By default provided by the ThemeProvider.
 **type:** `Array<TabItem>`  
 
 Array of Tabs. Each `TabItem` needs to have below shape:
-* `icon`: [Icon name](icon.html#name) (optional)
+* `icon`: [Icon name](icon#name) (optional)
 * `title: string` (optional)
 * `onPress: function` - to be called when Tab is tapped
 * `isActive: boolean` (optional) - indicating whether Tab is active

--- a/website/docs/table-view.md
+++ b/website/docs/table-view.md
@@ -5,7 +5,7 @@ title: TableView
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 A basic TableView component that can render iOS table view.
-It renders header, footer and children which can be [`RowItem`](row-item.html) components.  
+It renders header, footer and children which can be [`RowItem`](row-item) components.  
 
 
 <img alt="TableView component " src={useBaseUrl('img/table-view.png')} />
@@ -33,12 +33,12 @@ import { ScrollView, TableView } from 'react-native-ios-kit';
 
 ## TableView rows
 There are few ready for use row components:
-- [`RowItem`](row-item.html) - basic row item
-- [`InfoRow`](info-row.html) - row with simple text
-- [`CheckboxRow`](checkbox-row.html) - row with checkbox
-- [`NavigationRow`](navigation-row.html) - row for navigation
-- [`SwitchRow`](switch-row.html) - row with switch
-- [`TextFieldRow`](text-field-row.html) - row with text field
+- [`RowItem`](row-item) - basic row item
+- [`InfoRow`](info-row) - row with simple text
+- [`CheckboxRow`](checkbox-row) - row with checkbox
+- [`NavigationRow`](navigation-row) - row for navigation
+- [`SwitchRow`](switch-row) - row with switch
+- [`TextFieldRow`](text-field-row) - row with text field
 
 
 ## Theme
@@ -52,7 +52,7 @@ Uses following theme properties:
 ### `children`
 **type:** `React.ChildrenArray<*>`
 
-Children of TableView. Could be [`RowItem`](row-item.html) components.
+Children of TableView. Could be [`RowItem`](row-item) components.
 
 ### `footer` (optional)
 **type:** `string`
@@ -80,7 +80,7 @@ Custom styles for header.
 Invoked on footer press.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/text-field-row.md
+++ b/website/docs/text-field-row.md
@@ -28,7 +28,7 @@ Uses following `theme` properties:
 
 ## Props
 
-### [RowItem props...](row-item.html#props)
+### [RowItem props...](row-item#props)
 
 Other props accepted by `RowItem` component.
 
@@ -43,7 +43,7 @@ Invoked with the new value when the value of text input changes.
 Placeholder value.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/text-field.md
+++ b/website/docs/text-field.md
@@ -55,7 +55,7 @@ Invoked with the new value when the value of text input changes.
 Placeholder value
 
 ### `theme`  
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 

--- a/website/docs/toolbar.md
+++ b/website/docs/toolbar.md
@@ -45,7 +45,7 @@ Uses following `theme` properties:
 ## Props
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.
 
@@ -53,7 +53,7 @@ Custom theme for component. By default provided by the ThemeProvider.
 **type:** `Array<ToolbarItem>`  
 
 Array of Items. Each `ToolbarItem` needs to have below shape:
-* `icon`: [Icon name](icon.html#name) (optional)
+* `icon`: [Icon name](icon#name) (optional)
 * `title: string` (optional)
 * `onPress: function` - to be called when Item is tapped
 * `disabled?: boolean` (optional) - disables an Item

--- a/website/docs/typography.md
+++ b/website/docs/typography.md
@@ -46,6 +46,6 @@ Uses following `theme` properties:
 Custom styles to apply to the typography component.
 
 ### `theme` (optional)
-**type:** [`Theme`](theme.html)
+**type:** [`Theme`](theme)
 
 Custom theme for component. By default provided by the ThemeProvider.

--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -11,7 +11,7 @@ function Help() {
         content:
           'Learn more using the documentation on this site.',
         title: 'Browse Docs',
-        link: 'react-native-ios-kit/docs/installation.html'
+        link: 'docs/installation'
       },
       {
         content: 'Ask questions about the documentation and project',


### PR DESCRIPTION
### Summary

Added `useTheme` section to docs.
![image](https://user-images.githubusercontent.com/13610886/81906443-8bd0c680-95c6-11ea-9a47-7ea25165599d.png)

Also, fixed broken internal links (docosaurus v2 don't need `.html` appended)