### PR TITLE
fix: do not run labeler action on fork

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   triage:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     name: Label issues and pull requests
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,10 @@ jobs:
         path: node_modules
         key: node-modules-${{ hashFiles('yarn.lock') }}
 
+    - name: Instal dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: yarn install --frozen-lockfile
+
     - name: Cache node modules @ website
       uses: actions/cache@v1
       id: cache-website
@@ -71,12 +75,20 @@ jobs:
         path: ./website/node_modules
         key: node-modules-website-${{ hashFiles('website/yarn.lock') }}
 
+    - name: Instal dependencies @ website
+      if: steps.cache-website.outputs.cache-hit != 'true'
+      run: yarn install --frozen-lockfile --cwd ./website
+
     - name: Cache node modules @ example
       uses: actions/cache@v1
       id: cache-example
       with:
         path: ./example/node_modules
         key: node-modules-example--${{ hashFiles('example/yarn.lock') }}
+
+    - name: Instal dependencies @ example
+      if: steps.cache-example.outputs.cache-hit != 'true'
+      run: yarn install --frozen-lockfile --cwd ./example
 
     - name: Run tests
       run: |


### PR DESCRIPTION
### Summary

Labeler Action wants to add labels for a forked repo for which it don't have access. We should disable it for this case.