### PR TITLE
RowItem - fix "Text strings must be rendered within a <Text> component" error when subtitle is empty string

### DIFF
--- a/src/components/RowItem.js
+++ b/src/components/RowItem.js
@@ -89,7 +89,7 @@ class RowItem extends React.Component<Props> {
           ]}
         >
           {!!title && <Body>{title}</Body>}
-          {subtitle && <Caption1>{subtitle}</Caption1>}
+          {!!subtitle && <Caption1>{subtitle}</Caption1>}
         </View>
         {this.renderRight()}
       </View>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
In RowItem, condition for displaying subtitle causes "Text strings must be rendered within a Text component" Error when subtitle is empty string.
This is because the condition uses subtitle itself and react native renders empty string when subtitle is empty.
I fixed the condition to use !!subtitle instead of subtitle.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->