### PR TITLE
chore: update actions to latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache
         with:
           path: node_modules
@@ -26,7 +26,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Cache node modules @ example
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache-example
         with:
           path: ./example/node_modules
@@ -37,7 +37,7 @@ jobs:
         run: yarn install --frozen-lockfile --cwd ./example
 
       - name: Cache node modules @ website
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache-website
         with:
           path: ./website/node_modules
@@ -53,24 +53,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('yarn.lock') }}
 
       - name: Cache node modules @ website
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache-website
         with:
           path: ./website/node_modules
           key: node-modules-website-${{ hashFiles('website/yarn.lock') }}
 
       - name: Cache node modules @ example
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache-example
         with:
           path: ./example/node_modules
@@ -90,24 +90,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('yarn.lock') }}
 
       - name: Cache node modules @ website
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache-website
         with:
           path: ./website/node_modules
           key: node-modules-website-${{ hashFiles('website/yarn.lock') }}
 
       - name: Cache node modules @ example
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache-example
         with:
           path: ./example/node_modules

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
     name: Label issues and pull requests
     steps:
       - name: check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: labeler
         uses: IvanFon/super-labeler-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache node modules
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: cache
       with:
         path: node_modules
@@ -27,7 +27,7 @@ jobs:
       run: yarn install --frozen-lockfile
 
     - name: Cache node modules @ example
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: cache-example
       with:
         path: ./example/node_modules
@@ -38,7 +38,7 @@ jobs:
       run: yarn install --frozen-lockfile --cwd ./example
 
     - name: Cache node modules @ website
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: cache-website
       with:
         path: ./website/node_modules
@@ -55,10 +55,10 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache node modules
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: cache
       with:
         path: node_modules
@@ -69,7 +69,7 @@ jobs:
       run: yarn install --frozen-lockfile
 
     - name: Cache node modules @ website
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: cache-website
       with:
         path: ./website/node_modules
@@ -80,7 +80,7 @@ jobs:
       run: yarn install --frozen-lockfile --cwd ./website
 
     - name: Cache node modules @ example
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: cache-example
       with:
         path: ./example/node_modules


### PR DESCRIPTION
### Summary

- Please update the following actions to use Node.js 20: actions/checkout@v2, actions/cache@v1.
- For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.